### PR TITLE
Fix stage count issue by auto-expanding localStorage data to 100 stages

### DIFF
--- a/scratch-reveal.html
+++ b/scratch-reveal.html
@@ -768,7 +768,18 @@
         function loadStagesFromStorage() {
             const saved = localStorage.getItem('scratchGameStages');
             if (saved) {
-                return JSON.parse(saved);
+                const loadedStages = JSON.parse(saved);
+                // 100ステージ未満の場合は100ステージに拡張
+                if (loadedStages.length < 100) {
+                    console.log(`ステージ数を${loadedStages.length}から100に拡張します`);
+                    while (loadedStages.length < 100) {
+                        const index = loadedStages.length;
+                        loadedStages.push(JSON.parse(JSON.stringify(defaultStages[index])));
+                    }
+                    // 拡張したデータを保存
+                    localStorage.setItem('scratchGameStages', JSON.stringify(loadedStages));
+                }
+                return loadedStages;
             }
             return JSON.parse(JSON.stringify(defaultStages)); // ディープコピー
         }


### PR DESCRIPTION
When users had saved data with only 10 stages from an earlier version, the app would continue to show only 10 stages. This fix automatically detects if the saved stage count is less than 100 and expands it to 100 stages using the default stage data.