### PR TITLE
Add automatic pair registration for batch image upload

### DIFF
--- a/scratch-reveal.html
+++ b/scratch-reveal.html
@@ -549,6 +549,14 @@
                 </div>
             </div>
 
+            <div style="margin-bottom: 15px;">
+                <div class="upload-box" id="pairUploadBox" onclick="document.getElementById('pairImageUpload').click()" style="border-color: #4CAF50; background: linear-gradient(135deg, #E8F5E9 0%, #F1F8E9 100%);">
+                    <h3 style="color: #2E7D32;">📌 ペア画像の一括登録</h3>
+                    <p style="color: #555;">作成日付順に自動ペア作成<br>1枚目→削る、2枚目→見せたい、3枚目→削る、4枚目→見せたい...</p>
+                    <input type="file" id="pairImageUpload" accept="image/*" multiple>
+                </div>
+            </div>
+
             <div class="comment-input-area">
                 <label>クリア時のコメント:</label>
                 <textarea id="commentInput" placeholder="70%削った時に表示されるメッセージを入力してください"></textarea>
@@ -649,6 +657,8 @@
         const playStageSelector = document.getElementById('playStageSelector');
         const topUploadBox = document.getElementById('topUploadBox');
         const bottomUploadBox = document.getElementById('bottomUploadBox');
+        const pairUploadBox = document.getElementById('pairUploadBox');
+        const pairImageUpload = document.getElementById('pairImageUpload');
 
         let currentStage = 0;
         let currentEditStage = 0;
@@ -993,6 +1003,85 @@
             }
         }
 
+        // ペア画像を一括処理（1枚目→削る、2枚目→見せたい、3枚目→削る...）
+        async function handlePairImages(files) {
+            if (files.length === 0) return;
+
+            const sortedFiles = sortFilesByDate(files);
+            const pairCount = Math.floor(sortedFiles.length / 2);
+            const remainingFiles = sortedFiles.length % 2;
+
+            const confirmed = await showConfirm(
+                `${sortedFiles.length}個の画像を作成日順にペアで一括登録します。\n` +
+                `${pairCount}組のペア（${pairCount * 2}枚）がステージ${currentEditStage + 1}から登録されます。\n` +
+                (remainingFiles > 0 ? `※ 残り${remainingFiles}枚は登録されません\n` : '') +
+                `よろしいですか？`
+            );
+
+            if (!confirmed) return;
+
+            let processedPairs = 0;
+            let failedCount = 0;
+
+            for (let i = 0; i < sortedFiles.length - 1; i += 2) {
+                const targetStage = currentEditStage + processedPairs;
+                if (targetStage >= stages.length) {
+                    alert(`ステージ${targetStage + 1}は存在しないため、残りの画像をスキップしました。`);
+                    break;
+                }
+
+                try {
+                    // 1枚目: 削る画像（topImage）
+                    const topFile = sortedFiles[i];
+                    const topReader = new FileReader();
+                    const topImageData = await new Promise((resolve, reject) => {
+                        topReader.onload = (e) => resolve(e.target.result);
+                        topReader.onerror = reject;
+                        topReader.readAsDataURL(topFile);
+                    });
+                    const topCompressed = await compressImage(topImageData);
+
+                    // 2枚目: 見せたい画像（bottomImage）
+                    const bottomFile = sortedFiles[i + 1];
+                    const bottomReader = new FileReader();
+                    const bottomImageData = await new Promise((resolve, reject) => {
+                        bottomReader.onload = (e) => resolve(e.target.result);
+                        bottomReader.onerror = reject;
+                        bottomReader.readAsDataURL(bottomFile);
+                    });
+                    const bottomCompressed = await compressImage(bottomImageData);
+
+                    // ペアで登録
+                    stages[targetStage].topImage = topCompressed;
+                    stages[targetStage].bottomImage = bottomCompressed;
+
+                    processedPairs++;
+                } catch (error) {
+                    console.error(`ペア ${processedPairs + 1} の処理に失敗:`, error);
+                    failedCount++;
+                }
+            }
+
+            // データを保存
+            try {
+                saveStages();
+                alert(
+                    `ペア一括登録が完了しました！\n` +
+                    `登録ペア数: ${processedPairs}組（${processedPairs * 2}枚）\n` +
+                    (failedCount > 0 ? `失敗: ${failedCount}組\n` : '') +
+                    (remainingFiles > 0 ? `未登録: ${remainingFiles}枚\n` : '') +
+                    `ステージ${currentEditStage + 1}〜${currentEditStage + processedPairs}に登録されました。`
+                );
+                loadEditStage(currentEditStage);
+            } catch (e) {
+                if (e.name === 'QuotaExceededError') {
+                    alert('保存容量を超えています。画像サイズが大きすぎる可能性があります。');
+                } else {
+                    alert('保存に失敗しました: ' + e.message);
+                }
+            }
+        }
+
         // 画像アップロード（単一・複数対応）
         topImageUpload.addEventListener('change', async (e) => {
             const files = e.target.files;
@@ -1030,6 +1119,32 @@
                 // 複数ファイルの場合は一括処理
                 await handleMultipleImages(files, '見せたい');
             }
+        });
+
+        // ペア画像アップロード
+        pairImageUpload.addEventListener('change', async (e) => {
+            const files = e.target.files;
+            if (!files || files.length === 0) return;
+
+            // 画像ファイルのみをフィルタ
+            const imageFiles = Array.from(files).filter(file =>
+                file.type.startsWith('image/')
+            );
+
+            if (imageFiles.length === 0) {
+                alert('画像ファイルを選択してください。');
+                return;
+            }
+
+            if (imageFiles.length < 2) {
+                alert('ペア登録には最低2枚の画像が必要です。');
+                return;
+            }
+
+            await handlePairImages(imageFiles);
+
+            // ファイル入力をリセット
+            pairImageUpload.value = '';
         });
 
         // ドラッグアンドドロップ機能
@@ -1098,9 +1213,58 @@
             });
         }
 
+        // ペアアップロード用のドラッグアンドドロップ機能
+        function setupPairDragAndDrop(uploadBox, fileInput) {
+            uploadBox.addEventListener('dragenter', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                uploadBox.classList.add('drag-over');
+            });
+
+            uploadBox.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                uploadBox.classList.add('drag-over');
+            });
+
+            uploadBox.addEventListener('dragleave', (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.target === uploadBox) {
+                    uploadBox.classList.remove('drag-over');
+                }
+            });
+
+            uploadBox.addEventListener('drop', async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                uploadBox.classList.remove('drag-over');
+
+                const files = e.dataTransfer.files;
+                if (!files || files.length === 0) return;
+
+                const imageFiles = Array.from(files).filter(file =>
+                    file.type.startsWith('image/')
+                );
+
+                if (imageFiles.length === 0) {
+                    alert('画像ファイルを選択してください。');
+                    return;
+                }
+
+                if (imageFiles.length < 2) {
+                    alert('ペア登録には最低2枚の画像が必要です。');
+                    return;
+                }
+
+                await handlePairImages(imageFiles);
+            });
+        }
+
         // ドラッグアンドドロップを両方のアップロードボックスに設定
         setupDragAndDrop(topUploadBox, topImageUpload, '削る');
         setupDragAndDrop(bottomUploadBox, bottomImageUpload, '見せたい');
+        setupPairDragAndDrop(pairUploadBox, pairImageUpload);
 
         // ステージ保存
         saveStageBtn.addEventListener('click', () => {


### PR DESCRIPTION
- Add new UI section for pair batch upload with green highlight
- Implement auto-pairing logic: 1st→top, 2nd→bottom, 3rd→top, 4th→bottom...
- Sort images by creation date before pairing
- Support both click and drag-and-drop for pair upload
- Handle odd number of images with user notification
- Process pairs sequentially starting from current edit stage